### PR TITLE
Revert "Bump @adobe/css-tools from 4.3.1 to 4.3.2 in /subdomain-enumeration-frontend"

### DIFF
--- a/subdomain-enumeration-frontend/package-lock.json
+++ b/subdomain-enumeration-frontend/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
-      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",


### PR DESCRIPTION
Reverts Project-Based-Learning-crew-3/subdomain-enumeration#17